### PR TITLE
Impossibile registrare nuovo utente

### DIFF
--- a/plugins/authentication/spid/spid.php
+++ b/plugins/authentication/spid/spid.php
@@ -16,7 +16,7 @@
 defined('_JEXEC') or die;
 
 /**
- * @version		3.8.0
+ * @version		3.8.1
  * @since		3.7
  */
 class plgAuthenticationSpid extends JPlugin
@@ -148,9 +148,9 @@ class plgAuthenticationSpid extends JPlugin
 
 					// Set and query the database.
 					$db->setQuery($query);
-					$username = $db->loadResult();
+					$username_new = $db->loadResult();
 
-					if ($username)
+					if ($username_new)
 					{
 						if ($allowEmailAuthentication == 2)
 						{
@@ -167,7 +167,7 @@ class plgAuthenticationSpid extends JPlugin
 							try
 							{
 								$db->execute();
-								$username = $attributes['fiscalNumber'][0];
+								$username_new = $attributes['fiscalNumber'][0];
 								$app->enqueueMessage(JText::sprintf('PLG_AUTHENTICATION_SPID_PROFILE_UPDATE_SUCCESS', $username), 'notice');
 							}
 							catch (Exception $e)
@@ -176,7 +176,7 @@ class plgAuthenticationSpid extends JPlugin
 						}
 
 						$response->status = JAuthentication::STATUS_SUCCESS;
-						$response->username = $username;
+						$response->username = $username_new;
 						$response->email = JStringPunycode::emailToPunycode($attributes['email'][0]);
 						$response->fullname = $attributes['name'][0].' '.$attributes['familyName'][0];
 

--- a/plugins/authentication/spid/spid.xml
+++ b/plugins/authentication/spid/spid.xml
@@ -2,12 +2,12 @@
 <extension version="3.0" type="plugin" group="authentication" method="upgrade">
   <name>plg_authentication_spid</name>
   <author>Helios Ciancio</author>
-  <creationDate>November 2017</creationDate>
-  <copyright>(C) 2017 Helios Ciancio. All rights reserved.</copyright>
+  <creationDate>January 2018</creationDate>
+  <copyright>(C) 2017, 2018 Helios Ciancio. All rights reserved.</copyright>
   <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3</license>
   <authorEmail>info@eshiol.it</authorEmail>
   <authorUrl>www.eshiol.it</authorUrl>
-  <version>3.8.0.110</version>
+  <version>3.8.1.111</version>
   <description>PLG_AUTHENTICATION_SPID_XML_DESCRIPTION</description>
   <updateservers>
     <server type="extension" priority="2" name="Authentication - SPiD">https://www.eshiol.it/files/spid/plg_authentication_spid.xml</server>


### PR DESCRIPTION
Impossibile registrare nuovo utente

Pull Request for Issue #6 .

### Summary of Changes
Corretto il bug relativo alla registrazione di un nuovo utente quando l'opzione Consenti autenticazione tramite email è impostata a Sì oppure Sì, aggiorna nome utente.

### Testing Instructions
Impostare le seguenti opzioni del plugin Authentication - SPiD
Consenti registrazione utenti: Sì
Consenti autenticazione tramite email: Sì
oppure
Consenti autenticazione tramite email: Sì, aggiorna nome utente
Accedere tramite SPiD utilizzando un utente non ancora registrato

### Expected result
![issue00006_001](https://user-images.githubusercontent.com/12718836/34839689-da25e442-f702-11e7-9557-786f94fc90b9.PNG)

### Actual result
Registrazione avvenuta con successo

### Documentation Changes Required
