### PR TITLE
Redirected after login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .settings
 .buildpath
 .project
+files/
+images/
 
 # Windows image file caches
 Thumbs.db

--- a/language/en-GB/en-GB.mod_spid_login.ini
+++ b/language/en-GB/en-GB.mod_spid_login.ini
@@ -1,5 +1,5 @@
-; SPiD Login Module - mod_spid_login 3.8.0
-; Copyright (C) 2017 Helios Ciancio. All rights reserved.
+; SPiD Login Module - mod_spid_login 3.8.1
+; Copyright (C) 2017, 2018 Helios Ciancio. All rights reserved.
 ; License GNU General Public License version 3 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
@@ -13,6 +13,8 @@ MOD_SPID_LOGIN_DEBUG_PHPCONSOLE_DESC=""
 MOD_SPID_LOGIN_DEBUG_PHPCONSOLE_LABEL="PHP Console"
 MOD_SPID_LOGIN_DEBUG_SYSTEM_DESC="If enabled, diagnostic information will be saved."
 MOD_SPID_LOGIN_DEBUG_SYSTEM_LABEL="Debug"
+MOD_SPID_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC="Select or create the page the user will be redirected to after a successful login. The default is to remain on the same page."
+MOD_SPID_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL="Login Redirection Page"
 MOD_SPID_LOGIN_FIELD_SHOW_HELPLINK_DESC=""
 MOD_SPID_LOGIN_FIELD_SHOW_HELPLINK_LABEL="Show help link"
 MOD_SPID_LOGIN_FIELD_SHOW_INFOLINK_DESC=""

--- a/language/it-IT/it-IT.mod_spid_login.ini
+++ b/language/it-IT/it-IT.mod_spid_login.ini
@@ -1,5 +1,5 @@
-; SPiD Login Module - mod_spid_login 3.8.0
-; Copyright (C) 2017 Helios Ciancio. All rights reserved.
+; SPiD Login Module - mod_spid_login 3.8.1
+; Copyright (C) 2017, 2018 Helios Ciancio. All rights reserved.
 ; License GNU General Public License version 3 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
@@ -13,6 +13,8 @@ MOD_SPID_LOGIN_DEBUG_PHPCONSOLE_DESC=""
 MOD_SPID_LOGIN_DEBUG_PHPCONSOLE_LABEL="PHP Console"
 MOD_SPID_LOGIN_DEBUG_SYSTEM_DESC="Se abilitato, verranno prodotte informazioni diagnostiche su file."
 MOD_SPID_LOGIN_DEBUG_SYSTEM_LABEL="Debug"
+MOD_SPID_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC="Seleziona o crea la pagina alla quale reindirizzare gli utenti dopo l'accesso all'area riservata. Di default rimane nella stessa pagina."
+MOD_SPID_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL="Redirezionamento dopo accesso"
 MOD_SPID_LOGIN_FIELD_SHOW_HELPLINK_DESC=""
 MOD_SPID_LOGIN_FIELD_SHOW_HELPLINK_LABEL="Visualizza help link"
 MOD_SPID_LOGIN_FIELD_SHOW_INFOLINK_DESC=""

--- a/modules/mod_spid_login/mod_spid_login.xml
+++ b/modules/mod_spid_login/mod_spid_login.xml
@@ -2,12 +2,12 @@
 <extension version="3.0" type="module" client="site" method="upgrade">
   <name>mod_spid_login</name>
   <author>Helios Ciancio</author>
-  <creationDate>November 2017</creationDate>
-  <copyright>(C) 2017 Helios Ciancio. All rights reserved.</copyright>
+  <creationDate>January 2018</creationDate>
+  <copyright>(C) 2017, 2018 Helios Ciancio. All rights reserved.</copyright>
   <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3</license>
   <authorEmail>info@eshiol.it</authorEmail>
   <authorUrl>www.eshiol.it</authorUrl>
-  <version>3.8.0.45</version>
+  <version>3.8.1.47</version>
   <description>MOD_SPID_LOGIN_XML_DESCRIPTION</description>
   <updateservers>
     <server type="extension" priority="2" name="SPiD Login">https://www.eshiol.it/files/spid/mod_spid_login.xml</server>
@@ -53,6 +53,9 @@
           <option value="0">JNO</option>
         </field>
         <field name="url_helplink" type="text" filter="url" label="MOD_SPID_LOGIN_FIELD_URL_HELPLINK_LABEL" description="MOD_SPID_LOGIN_FIELD_URL_HELPLINK_DESC" class="input-xxlarge input-large-text" hint="MOD_SPID_LOGIN_FIELD_URL_HELPLINK_DEFAULT" showon="show_helplink:1"/>
+        <field name="login" type="modal_menu" label="MOD_SPID_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL" description="MOD_SPID_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC" disable="separator,alias,heading,url" select="true" new="true" edit="true" clear="true" addfieldpath="/administrator/components/com_menus/models/fields">
+          <option value="">JDEFAULT</option>
+        </field>
       </fieldset>
       <fieldset name="advanced">
         <field name="layout" type="modulelayout" label="JFIELD_ALT_LAYOUT_LABEL" description="JFIELD_ALT_MODULE_LAYOUT_DESC"/>


### PR DESCRIPTION
### Summary of Changes
Seleziona o crea la pagina alla quale reindirizzare gli utenti dopo l'accesso all'area riservata. Di default rimane nella stessa pagina.

### Testing Instructions
Aggiungi il modulo SPiD Login ed imposta l'opzione Redirezionamento dopo accesso
![spid0014](https://user-images.githubusercontent.com/12718836/34987327-0ab98558-fabb-11e7-9946-aa0a9fed5230.png)

### Expected result
L'utente viene reindirizzato alla pagina scelta dopo l'accesso.

### Actual result

### Documentation Changes Required
E' possibile selezionare o creare la pagina alla quale reindirizzare gli utenti dopo l'accesso all'area riservata. Di default rimane nella stessa pagina.
![spid0014](https://user-images.githubusercontent.com/12718836/34987327-0ab98558-fabb-11e7-9946-aa0a9fed5230.png)
