### PR TITLE
Simplasaml check

### DIFF
--- a/administrator/manifests/packages/pkg_spid.xml
+++ b/administrator/manifests/packages/pkg_spid.xml
@@ -2,11 +2,11 @@
 <extension type="package" version="3.0" method="upgrade">
   <name>pkg_spid</name>
   <author>Helios Ciancio</author>
-  <creationDate>November 2017</creationDate>
-  <copyright>(C) 2017 Helios Ciancio. All rights reserved.</copyright>
+  <creationDate>February 2018</creationDate>
+  <copyright>(C) 2017, 2018 Helios Ciancio. All rights reserved.</copyright>
   <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3</license>
   <packagename>spid</packagename>
-  <version>3.8.0.17</version>
+  <version>3.8.3</version>
   <url>https://www.eshiol.it</url>
   <packager>Helios Ciancio</packager>
   <packagerurl>https://www.eshiol.it/</packagerurl>
@@ -17,7 +17,7 @@
   <files>
     <folder type="plugin" id="spid" group="authentication">plg_authentication_spid-3.8.0.110.zip</folder>
     <folder type="plugin" id="spid" group="user">plg_user_spid-3.8.0.17.zip</folder>
-    <folder type="module" id="spid" client="site">mod_spid_login-3.8.0.45.zip</folder>
+    <folder type="module" id="spid" client="site">mod_spid_login-3.8.3.zip</folder>
   </files>
   <languages folder="language">
     <language tag="en-GB">en-GB/en-GB.pkg_spid.sys.ini</language>

--- a/plugins/authentication/spid/spid.php
+++ b/plugins/authentication/spid/spid.php
@@ -16,7 +16,7 @@
 defined('_JEXEC') or die;
 
 /**
- * @version		3.8.1
+ * @version		3.8.2
  * @since		3.7
  */
 class plgAuthenticationSpid extends JPlugin
@@ -83,6 +83,8 @@ class plgAuthenticationSpid extends JPlugin
 	public function onUserAuthenticate($credentials, $options, &$response)
 	{
 		JLog::add(new JLogEntry(__METHOD__, JLog::DEBUG, 'plg_authentication_spid'));
+
+		if (!class_exists('SimpleSAML')) return true;
 
 		$app    = JFactory::getApplication();
 		$input  = $app->input;

--- a/plugins/authentication/spid/spid.xml
+++ b/plugins/authentication/spid/spid.xml
@@ -2,12 +2,12 @@
 <extension version="3.0" type="plugin" group="authentication" method="upgrade">
   <name>plg_authentication_spid</name>
   <author>Helios Ciancio</author>
-  <creationDate>January 2018</creationDate>
+  <creationDate>February 2018</creationDate>
   <copyright>(C) 2017, 2018 Helios Ciancio. All rights reserved.</copyright>
   <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3</license>
   <authorEmail>info@eshiol.it</authorEmail>
   <authorUrl>www.eshiol.it</authorUrl>
-  <version>3.8.1.111</version>
+  <version>3.8.2</version>
   <description>PLG_AUTHENTICATION_SPID_XML_DESCRIPTION</description>
   <updateservers>
     <server type="extension" priority="2" name="Authentication - SPiD">https://www.eshiol.it/files/spid/plg_authentication_spid.xml</server>

--- a/plugins/user/spid/spid.php
+++ b/plugins/user/spid/spid.php
@@ -16,7 +16,7 @@
 defined('_JEXEC') or die;
 
 /**
- * @version		3.8.0
+ * @version		3.8.1
  * @since		3.7
  */
 class plgUserSpid extends JPlugin
@@ -89,6 +89,8 @@ class plgUserSpid extends JPlugin
 	public function onUserLogout($user, $options = array())
 	{
 		JLog::add(new JLogEntry(__METHOD__, JLog::DEBUG, 'plg_user_spid'));
+
+		if (!class_exists('SimpleSAML')) return true;
 
 		// Load the authentication source from the session.
 		$authsource = JFactory::getSession()->get('spid.authsource', 'default-sp');

--- a/plugins/user/spid/spid.xml
+++ b/plugins/user/spid/spid.xml
@@ -2,12 +2,12 @@
 <extension version="3.0" type="plugin" group="user" method="upgrade">
   <name>plg_user_spid</name>
   <author>Helios Ciancio</author>
-  <creationDate>November 2017</creationDate>
-  <copyright>(C) 2017 Helios Ciancio. All rights reserved.</copyright>
+  <creationDate>February 2018</creationDate>
+  <copyright>(C) 2017, 2018 Helios Ciancio. All rights reserved.</copyright>
   <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3</license>
   <authorEmail>info@eshiol.it</authorEmail>
   <authorUrl>www.eshiol.it</authorUrl>
-  <version>3.8.0.17</version>
+  <version>3.8.1</version>
   <description>PLG_USER_SPID_XML_DESCRIPTION</description>
   <updateservers>
     <server type="extension" priority="2" name="User - SPiD">https://www.eshiol.it/files/spid/plg_user_spid.xml</server>


### PR DESCRIPTION
### Summary of Changes
Corretto errore 500 su logout

### Testing Instructions
Installare il pacchetto SPiD senza installare la libreria simplespidphp
Attivare il plugin User - SPiD
Effettuare il login al front-end del sito
Effettuare il logout

### Expected result
Logout perfettamente eseguito

### Actual result
![spid0029](https://user-images.githubusercontent.com/12718836/36774282-ae67653a-1c5d-11e8-824a-404cbf53534c.png)
