### PR TITLE
logout error 500

### DIFF
--- a/plugins/user/spid/spid.php
+++ b/plugins/user/spid/spid.php
@@ -5,7 +5,7 @@
  *
  * @author		Helios Ciancio <info@eshiol.it>
  * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017 Helios Ciancio. All Rights Reserved
+ * @copyright	Copyright (C) 2017, 2018 Helios Ciancio. All Rights Reserved
  * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
  * SPiD for Joomla! is free software. This version may have been modified pursuant
  * to the GNU General Public License, and as distributed it includes or
@@ -16,7 +16,7 @@
 defined('_JEXEC') or die;
 
 /**
- * @version		3.8.0
+ * @version		3.8.1
  * @since		3.7
  */
 class plgUserSpid extends JPlugin
@@ -27,14 +27,14 @@ class plgUserSpid extends JPlugin
 	 * @var    boolean
 	 */
 	protected $autoloadLanguage = true;
-
+	
 	/**
 	 * Database object
 	 *
 	 * @var    JDatabaseDriver
 	 */
 	protected $db;
-
+	
 	/**
 	 * Constructor
 	 *
@@ -44,7 +44,7 @@ class plgUserSpid extends JPlugin
 	function __construct(&$subject, $config)
 	{
 		parent::__construct($subject, $config);
-
+		
 		if ($this->params->get('debug') || defined('JDEBUG') && JDEBUG)
 		{
 			JLog::addLogger(array('text_file' => $this->params->get('log', 'eshiol.log.php'), 'extension' => 'plg_user_spid_file'), JLog::ALL, array('plg_user_spid'));
@@ -55,7 +55,7 @@ class plgUserSpid extends JPlugin
 			JLog::addLogger(array('logger' => 'phpconsole', 'extension' => 'plg_user_spid_phpconsole'),  JLOG::DEBUG, array('plg_user_spid'));
 		}
 		JLog::add(new JLogEntry(__METHOD__, JLog::DEBUG, 'plg_user_spid'));
-
+		
 		// Use Composers autoloading
 		if (!class_exists('SimpleSAML'))
 		{
@@ -77,7 +77,7 @@ class plgUserSpid extends JPlugin
 			}
 		}
 	}
-
+	
 	/**
 	 * Method to handle any logout logic and report back to the subject.
 	 *
@@ -89,16 +89,18 @@ class plgUserSpid extends JPlugin
 	public function onUserLogout($user, $options = array())
 	{
 		JLog::add(new JLogEntry(__METHOD__, JLog::DEBUG, 'plg_user_spid'));
-
+		
+		if (!class_exists('SimpleSAML')) return true;
+		
 		// Load the authentication source from the session.
 		$authsource = JFactory::getSession()->get('spid.authsource', 'default-sp');
-
+		
 		$as = new SimpleSAML_Auth_Simple($authsource);
 		if ($as->isAuthenticated())
 		{
-		    $as->logout();
+			$as->logout();
 		}
-
+		
 		return true;
 	}
 }

--- a/plugins/user/spid/spid.xml
+++ b/plugins/user/spid/spid.xml
@@ -2,12 +2,12 @@
 <extension version="3.0" type="plugin" group="user" method="upgrade">
   <name>plg_user_spid</name>
   <author>Helios Ciancio</author>
-  <creationDate>November 2017</creationDate>
-  <copyright>(C) 2017 Helios Ciancio. All rights reserved.</copyright>
+  <creationDate>February 2018</creationDate>
+  <copyright>(C) 2017, 2018 Helios Ciancio. All rights reserved.</copyright>
   <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3</license>
   <authorEmail>info@eshiol.it</authorEmail>
   <authorUrl>www.eshiol.it</authorUrl>
-  <version>3.8.0.17</version>
+  <version>3.8.1</version>
   <description>PLG_USER_SPID_XML_DESCRIPTION</description>
   <updateservers>
     <server type="extension" priority="2" name="User - SPiD">https://www.eshiol.it/files/spid/plg_user_spid.xml</server>


### PR DESCRIPTION
### Summary of Changes
Corretto errore 500 su logout

### Testing Instructions
Installare il pacchetto SPiD senza installare la libreria simplespidphp
Attivare il plugin User - SPiD
Effettuare il login al front-end del sito
Effettuare il logout

### Expected result
Logout perfettamente eseguito

### Actual result
![spid0029](https://user-images.githubusercontent.com/12718836/36774282-ae67653a-1c5d-11e8-824a-404cbf53534c.png)
