### PR TITLE
Update spid.php

### DIFF
--- a/plugins/system/spid/spid.php
+++ b/plugins/system/spid/spid.php
@@ -180,7 +180,11 @@ class plgSystemSpid extends JPlugin
 			$e = $s['SimpleSAML_Auth_State.exceptionData'];
 			$lang = JFactory::getLanguage();
 			$message = $e->getMessage();
-			$key = 'PLG_SYSTEM_SPID_' . str_replace(' ', '_', strtoupper($message));
+            		$MESSAGE = str_replace(' ', '_', strtoupper($message));
+            		$error_suffix = ( strpos( $MESSAGE, '_ERRORCODE_NR' ) !== false )
+                            ? substr( $MESSAGE , ( strpos( $MESSAGE, '_ERRORCODE_NR' ) + 1 ) )
+                            : $MESSAGE;
+			$key = 'PLG_SYSTEM_SPID_' . $error_suffix;
 			JLog::add(
 					new JLogEntry($lang->hasKey($key) ? JText::_($key) : JText::sprintf('PLG_SYSTEM_SPID_ERRORCODE_UNKNOWN', $message), JLog::WARNING,
 							'plg_system_spid'));

--- a/plugins/system/spid/spid.php
+++ b/plugins/system/spid/spid.php
@@ -180,11 +180,9 @@ class plgSystemSpid extends JPlugin
 			$e = $s['SimpleSAML_Auth_State.exceptionData'];
 			$lang = JFactory::getLanguage();
 			$message = $e->getMessage();
-            		$MESSAGE = str_replace(' ', '_', strtoupper($message));
-            		$error_suffix = ( strpos( $MESSAGE, '_ERRORCODE_NR' ) !== false )
-                            ? substr( $MESSAGE , ( strpos( $MESSAGE, '_ERRORCODE_NR' ) + 1 ) )
-                            : $MESSAGE;
-			$key = 'PLG_SYSTEM_SPID_' . $error_suffix;
+			$m = str_replace(' ', '_', strtoupper($message));
+			$esfx = (strpos($m, '_ERRORCODE_NR') !== false) ? substr($m, (strpos($m, '_ERRORCODE_NR') + 1)) : $m;
+			$key = 'PLG_SYSTEM_SPID_' . $esfx;
 			JLog::add(
 					new JLogEntry($lang->hasKey($key) ? JText::_($key) : JText::sprintf('PLG_SYSTEM_SPID_ERRORCODE_UNKNOWN', $message), JLog::WARNING,
 							'plg_system_spid'));


### PR DESCRIPTION
Per qualunque tipo di errore, a partire dall'annullamento dell'utente, ricevevamo l'errore generico
PLG_SYSTEM_SPID_ERRORCODE_UNKNOWN

L'applicazione di questa patch, consente di sollevare gli errori specifici già previsti nei seguenti file di linguaggio:
PLG_SYSTEM_SPID_ERRORCODE_NR2
PLG_SYSTEM_SPID_ERRORCODE_NR3
PLG_SYSTEM_SPID_ERRORCODE_NR12
PLG_SYSTEM_SPID_ERRORCODE_NR19
PLG_SYSTEM_SPID_ERRORCODE_NR20
PLG_SYSTEM_SPID_ERRORCODE_NR21
PLG_SYSTEM_SPID_ERRORCODE_NR22
PLG_SYSTEM_SPID_ERRORCODE_NR23
PLG_SYSTEM_SPID_ERRORCODE_NR25

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

